### PR TITLE
Hotfix/handleKeyPress

### DIFF
--- a/src/components/KeywordRecommendItem/index.tsx
+++ b/src/components/KeywordRecommendItem/index.tsx
@@ -9,9 +9,10 @@ import { IDisease } from 'types/search'
 
 interface SearchKeywordRecommendItemProps {
   resultData: IDisease
+  isFocusTrue: boolean
 }
 
-const KeywordRecommendItem = ({ resultData }: SearchKeywordRecommendItemProps) => {
+const KeywordRecommendItem = ({ resultData, isFocusTrue }: SearchKeywordRecommendItemProps) => {
   const dispatch = useDispatch()
 
   // TODO: 라우팅되도록. 예제 사이트 보시면 추천 검색어 클릭시 결과 페이지로 넘어갑니다.
@@ -20,7 +21,7 @@ const KeywordRecommendItem = ({ resultData }: SearchKeywordRecommendItemProps) =
   }
 
   return (
-    <li className={cx(styles.listKeyword)} value={resultData.sickNm}>
+    <li className={cx(styles.listKeyword, { [styles.focusKeyword]: isFocusTrue })} value={resultData.sickNm}>
       <button type='button' className={styles.keywordBtn} onClick={handleKeywordClick}>
         <div className={styles.icon}>
           <MagnifyingGlassIcon className={styles.icon} />

--- a/src/components/KeywordRecommendItem/index.tsx
+++ b/src/components/KeywordRecommendItem/index.tsx
@@ -1,4 +1,5 @@
 import { useDispatch } from 'react-redux'
+import { useNavigate } from 'react-router-dom'
 import cx from 'classnames'
 
 import { ISearchState, setSearchWord } from 'store/slices/searchSlice'
@@ -14,10 +15,12 @@ interface SearchKeywordRecommendItemProps {
 
 const KeywordRecommendItem = ({ resultData, isFocusTrue }: SearchKeywordRecommendItemProps) => {
   const dispatch = useDispatch()
+  const navigate = useNavigate()
 
   // TODO: 라우팅되도록. 예제 사이트 보시면 추천 검색어 클릭시 결과 페이지로 넘어갑니다.
   const handleKeywordClick = () => {
     dispatch(setSearchWord({ keyword: resultData.sickNm } as ISearchState))
+    navigate(`/search/${resultData.sickNm}`)
   }
 
   return (

--- a/src/components/KeywordRecommendItem/index.tsx
+++ b/src/components/KeywordRecommendItem/index.tsx
@@ -17,7 +17,6 @@ const KeywordRecommendItem = ({ resultData, isFocusTrue }: SearchKeywordRecommen
   const dispatch = useDispatch()
   const navigate = useNavigate()
 
-  // TODO: 라우팅되도록. 예제 사이트 보시면 추천 검색어 클릭시 결과 페이지로 넘어갑니다.
   const handleKeywordClick = () => {
     dispatch(setSearchWord({ keyword: resultData.sickNm } as ISearchState))
     navigate(`/search/${resultData.sickNm}`)

--- a/src/components/KeywordRecommendItem/index.tsx
+++ b/src/components/KeywordRecommendItem/index.tsx
@@ -9,10 +9,9 @@ import { IDisease } from 'types/search'
 
 interface SearchKeywordRecommendItemProps {
   resultData: IDisease
-  isFocusTrue: boolean
 }
 
-const KeywordRecommendItem = ({ resultData, isFocusTrue }: SearchKeywordRecommendItemProps) => {
+const KeywordRecommendItem = ({ resultData }: SearchKeywordRecommendItemProps) => {
   const dispatch = useDispatch()
 
   // TODO: 라우팅되도록. 예제 사이트 보시면 추천 검색어 클릭시 결과 페이지로 넘어갑니다.
@@ -22,7 +21,7 @@ const KeywordRecommendItem = ({ resultData, isFocusTrue }: SearchKeywordRecommen
   }
 
   return (
-    <li className={cx(styles.listKeyword, { [styles.focusKeyword]: isFocusTrue })} value={resultData.sickNm}>
+    <li className={cx(styles.listKeyword)} value={resultData.sickNm}>
       <button type='button' className={styles.keywordBtn} onClick={handleKeywordClick}>
         <div className={styles.icon}>
           <MagnifyingGlassIcon className={styles.icon} />

--- a/src/components/KeywordRecommendItem/index.tsx
+++ b/src/components/KeywordRecommendItem/index.tsx
@@ -1,7 +1,7 @@
 import { useDispatch } from 'react-redux'
 import cx from 'classnames'
 
-import { ISearchState, setSearchToggle, setSearchWord } from 'store/slices/searchSlice'
+import { ISearchState, setSearchWord } from 'store/slices/searchSlice'
 import { MagnifyingGlassIcon } from 'assets/svgs'
 
 import styles from './KeywordRecommendItem.module.scss'
@@ -17,7 +17,6 @@ const KeywordRecommendItem = ({ resultData }: SearchKeywordRecommendItemProps) =
   // TODO: 라우팅되도록. 예제 사이트 보시면 추천 검색어 클릭시 결과 페이지로 넘어갑니다.
   const handleKeywordClick = () => {
     dispatch(setSearchWord({ keyword: resultData.sickNm } as ISearchState))
-    dispatch(setSearchToggle({ isOpen: false } as ISearchState))
   }
 
   return (

--- a/src/components/KeywordRecommends/index.tsx
+++ b/src/components/KeywordRecommends/index.tsx
@@ -1,24 +1,48 @@
+import { useMemo } from 'react'
+import { useSelector } from 'react-redux'
+import { useQuery } from 'react-query'
+
+import { getDiseaseData } from 'services/search'
+import { searchWord } from 'store/slices/searchSlice'
 import { IDisease } from 'types/search'
+import { useQueryDebounce } from 'hooks'
 import KeywordRecommendItem from 'components/KeywordRecommendItem'
 
 import styles from './KeywordRecommends.module.scss'
 
-interface IKeywordRecommends {
-  data: IDisease[] | undefined
-  keywordIndex: number
-  setTarget: any
-}
+const KeywordRecommends = () => {
+  const keyword = useSelector(searchWord)
+  const debouncedKeyword = useQueryDebounce(keyword, 300)
 
-const KeywordRecommends = ({ data, keywordIndex, setTarget }: IKeywordRecommends) => {
-  return (
-    <div className={styles.keywordListForm}>
-      <ul className={styles.list} ref={setTarget}>
-        {data?.map((resultData: IDisease, idx) => (
-          <KeywordRecommendItem key={resultData.sickCd} resultData={resultData} isFocusTrue={keywordIndex === idx} />
+  const { data, isLoading, isError, error } = useQuery<IDisease[], Error>(
+    ['diseaseData', debouncedKeyword],
+    () => getDiseaseData(debouncedKeyword),
+    {
+      retry: 1,
+      staleTime: 60 * 60 * 1000,
+      enabled: !!debouncedKeyword,
+    }
+  )
+
+  const Recommends = useMemo(() => {
+    if (isLoading) {
+      return <div className={styles.list}>Loading...</div>
+    }
+
+    if (isError) {
+      return <div>{error.message}</div>
+    }
+
+    return (
+      <ul>
+        {data?.map((resultData: IDisease) => (
+          <KeywordRecommendItem key={resultData.sickCd} resultData={resultData} />
         ))}
       </ul>
-    </div>
-  )
+    )
+  }, [data, error, isError, isLoading])
+
+  return <div className={styles.keywordListForm}>{Recommends}</div>
 }
 
 export default KeywordRecommends

--- a/src/components/KeywordRecommends/index.tsx
+++ b/src/components/KeywordRecommends/index.tsx
@@ -1,16 +1,17 @@
 import { useMemo } from 'react'
-import { useSelector } from 'react-redux'
+import { useSelector, useDispatch } from 'react-redux'
 import { useQuery } from 'react-query'
 
 import { getDiseaseData } from 'services/search'
-import { searchWord } from 'store/slices/searchSlice'
+import { ISearchState, searchWord, setRecommendsCount } from 'store/slices/searchSlice'
 import { IDisease } from 'types/search'
 import { useQueryDebounce } from 'hooks'
 import KeywordRecommendItem from 'components/KeywordRecommendItem'
 
 import styles from './KeywordRecommends.module.scss'
 
-const KeywordRecommends = () => {
+const KeywordRecommends = ({ keywordIndex }: any) => {
+  const dispatch = useDispatch()
   const keyword = useSelector(searchWord)
   const debouncedKeyword = useQueryDebounce(keyword, 300)
 
@@ -21,6 +22,9 @@ const KeywordRecommends = () => {
       retry: 1,
       staleTime: 60 * 60 * 1000,
       enabled: !!debouncedKeyword,
+      onSuccess: (res) => {
+        dispatch(setRecommendsCount({ recommendsCount: res.length } as ISearchState))
+      },
     }
   )
 
@@ -35,12 +39,12 @@ const KeywordRecommends = () => {
 
     return (
       <ul>
-        {data?.map((resultData: IDisease) => (
-          <KeywordRecommendItem key={resultData.sickCd} resultData={resultData} />
+        {data?.map((resultData: IDisease, index) => (
+          <KeywordRecommendItem key={resultData.sickCd} resultData={resultData} isFocusTrue={keywordIndex === index} />
         ))}
       </ul>
     )
-  }, [data, error, isError, isLoading])
+  }, [data, error, isError, isLoading, keywordIndex])
 
   return <div className={styles.keywordListForm}>{Recommends}</div>
 }

--- a/src/components/KeywordRecommends/index.tsx
+++ b/src/components/KeywordRecommends/index.tsx
@@ -10,7 +10,7 @@ import KeywordRecommendItem from 'components/KeywordRecommendItem'
 
 import styles from './KeywordRecommends.module.scss'
 
-const KeywordRecommends = ({ keywordIndex }: any) => {
+const KeywordRecommends = ({ keywordIndex }: { keywordIndex: number }) => {
   const dispatch = useDispatch()
   const keyword = useSelector(searchWord)
   const debouncedKeyword = useQueryDebounce(keyword, 300)

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -2,7 +2,7 @@ import { ChangeEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 
-import { searchWord, ISearchState, setSearchToggle, setSearchWord } from 'store/slices/searchSlice'
+import { searchWord, ISearchState, setSearchWord } from 'store/slices/searchSlice'
 import { MagnifyingGlassIcon } from 'assets/svgs'
 
 import styles from './SearchBar.module.scss'
@@ -21,13 +21,6 @@ const SearchBar = () => {
     const { value } = e.currentTarget
 
     dispatch(setSearchWord({ keyword: value } as ISearchState))
-
-    if (value === '') {
-      dispatch(setSearchToggle({ isOpen: false } as ISearchState))
-      return
-    }
-
-    dispatch(setSearchToggle({ isOpen: true } as ISearchState))
   }
 
   const handleKeywordClick = () => {

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -7,7 +7,7 @@ import { MagnifyingGlassIcon } from 'assets/svgs'
 
 import styles from './SearchBar.module.scss'
 
-const SearchBar = () => {
+const SearchBar = ({ onKeyPress }: any) => {
   const dispatch = useDispatch()
   const navigate = useNavigate()
   const keyword = useSelector(searchWord)
@@ -19,7 +19,6 @@ const SearchBar = () => {
 
   const handleKeywordChange = (e: ChangeEvent<HTMLInputElement>) => {
     const { value } = e.currentTarget
-
     dispatch(setSearchWord({ keyword: value } as ISearchState))
   }
 
@@ -29,6 +28,7 @@ const SearchBar = () => {
         <MagnifyingGlassIcon />
       </div>
       <input
+        onKeyDown={onKeyPress}
         className={styles.input}
         type='search'
         placeholder='질환명을 입력해주세요.'

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent } from 'react'
+import { ChangeEvent, FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -12,7 +12,7 @@ const SearchBar = () => {
   const navigate = useNavigate()
   const keyword = useSelector(searchWord)
 
-  const handleKeywordSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const handleKeywordSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
     navigate(`/search/${keyword}`)
   }
@@ -21,10 +21,6 @@ const SearchBar = () => {
     const { value } = e.currentTarget
 
     dispatch(setSearchWord({ keyword: value } as ISearchState))
-  }
-
-  const handleKeywordClick = () => {
-    navigate(`/search/${keyword}`)
   }
 
   return (
@@ -39,7 +35,7 @@ const SearchBar = () => {
         value={keyword}
         onChange={handleKeywordChange}
       />
-      <button className={styles.button} type='button' onClick={handleKeywordClick}>
+      <button className={styles.button} type='submit'>
         검색
       </button>
     </form>

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -7,7 +7,7 @@ import { MagnifyingGlassIcon } from 'assets/svgs'
 
 import styles from './SearchBar.module.scss'
 
-const SearchBar = ({ onKeyPress }: any) => {
+const SearchBar = ({ onKeyPress }: { onKeyPress: React.KeyboardEventHandler<HTMLInputElement> }) => {
   const dispatch = useDispatch()
   const navigate = useNavigate()
   const keyword = useSelector(searchWord)

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -7,11 +7,7 @@ import { MagnifyingGlassIcon } from 'assets/svgs'
 
 import styles from './SearchBar.module.scss'
 
-interface ISearchBar {
-  handleKeyDown: any // KeyboardEventHandler<HTMLInputElement> | undefined
-}
-
-const SearchBar = ({ handleKeyDown }: ISearchBar) => {
+const SearchBar = () => {
   const dispatch = useDispatch()
   const navigate = useNavigate()
   const keyword = useSelector(searchWord)
@@ -49,7 +45,6 @@ const SearchBar = ({ handleKeyDown }: ISearchBar) => {
         placeholder='질환명을 입력해주세요.'
         value={keyword}
         onChange={handleKeywordChange}
-        onKeyDown={handleKeyDown}
       />
       <button className={styles.button} type='button' onClick={handleKeywordClick}>
         검색

--- a/src/routes/SearchPage/index.tsx
+++ b/src/routes/SearchPage/index.tsx
@@ -1,68 +1,37 @@
-import { useState, useMemo } from 'react'
-import { useSelector } from 'react-redux'
-import { useQuery } from 'react-query'
-
-import { getDiseaseData } from 'services/search'
-import { useQueryDebounce } from 'hooks'
-import { searchWord } from 'store/slices/searchSlice'
 import SearchBar from 'components/SearchBar'
 import KeywordRecommends from 'components/KeywordRecommends'
 
 import styles from './SearchPage.module.scss'
-import { IDisease } from 'types/search'
 
 const SearchPage = () => {
-  const keyword = useSelector(searchWord)
-  const debouncedKeyword = useQueryDebounce(keyword, 300)
+  // const [keywordIndex, setKeywordIndex] = useState(-1)
+  // const [target, setTarget] = useState<any>()
 
-  const [keywordIndex, setKeywordIndex] = useState(-1)
-  const [target, setTarget] = useState<any>()
-
-  const { data, isLoading, isError, error } = useQuery<IDisease[], Error>(
-    ['diseaseData', debouncedKeyword],
-    () => getDiseaseData(debouncedKeyword),
-    {
-      retry: 1,
-      staleTime: 60 * 60 * 1000,
-      enabled: !!debouncedKeyword,
-    }
-  )
-
-  const handleKeyDown = (e: KeyboardEvent) => {
-    if (!data) {
-      switch (e.key) {
-        case 'ArrowDown':
-          setKeywordIndex((prevState) => prevState + 1)
-          if (target.current?.childElementCount === keywordIndex + 1) setKeywordIndex(0)
-          break
-        case 'ArrowUp':
-          setKeywordIndex((prevState) => prevState - 1)
-          if (keywordIndex <= 0) {
-            // resultDataList([])
-            setKeywordIndex(-1)
-          }
-          break
-        case 'Escape':
-          setKeywordIndex(-1)
-          // resultDataList([])
-          break
-      }
-    }
-  }
+  // TODO: handleKeyDown 함수 위치 조정 및 data 의존성 제거
+  // const handleKeyDown = (e: KeyboardEvent) => {
+  //   if (data) {
+  //     switch (e.key) {
+  //       case 'ArrowDown':
+  //         setKeywordIndex((prevState) => prevState + 1)
+  //         if (target.current?.childElementCount === keywordIndex + 1) setKeywordIndex(0)
+  //         break
+  //       case 'ArrowUp':
+  //         setKeywordIndex((prevState) => prevState - 1)
+  //         if (keywordIndex <= 0) {
+  //           // resultDataList([])
+  //           setKeywordIndex(-1)
+  //         }
+  //         break
+  //       case 'Escape':
+  //         setKeywordIndex(-1)
+  //         // resultDataList([])
+  //         break
+  //     }
+  //   }
+  // }
 
   // memo: 강의 코드리뷰에서 나왔던 스타일로 리팩토링 했습니다.
   // TODO: 스타일 작업 필요
-  const Recommends = useMemo(() => {
-    if (isLoading) {
-      return <div>Loading...</div>
-    }
-
-    if (isError) {
-      return <div>{error.message}</div>
-    }
-
-    return <KeywordRecommends data={data} keywordIndex={keywordIndex} setTarget={setTarget} />
-  }, [data, error, isError, isLoading, keywordIndex])
 
   // memo: 아래 코드가 data의 status를 변경시킵니다.
   // useEffect(() => {
@@ -84,8 +53,8 @@ const SearchPage = () => {
           <br />
           온라인으로 참여하기
         </h1>
-        <SearchBar handleKeyDown={handleKeyDown} />
-        {Recommends}
+        <SearchBar />
+        <KeywordRecommends />
         <div className={styles.backgroundBottom}>
           <div className={styles.notification}>
             <p className={styles.notificationTxt}>새로운 임상시험이 등록되면 문자로 알려드려요</p>

--- a/src/routes/SearchPage/index.tsx
+++ b/src/routes/SearchPage/index.tsx
@@ -1,42 +1,44 @@
+import { useState } from 'react'
+import { useSelector } from 'react-redux'
+
+import { searchWord, recommendsCount } from 'store/slices/searchSlice'
 import SearchBar from 'components/SearchBar'
 import KeywordRecommends from 'components/KeywordRecommends'
 
 import styles from './SearchPage.module.scss'
 
 const SearchPage = () => {
-  // const [keywordIndex, setKeywordIndex] = useState(-1)
-  // const [target, setTarget] = useState<any>()
+  const keyword = useSelector(searchWord)
+  const count = useSelector(recommendsCount)
+  const [keywordIndex, setKeywordIndex] = useState(-1)
 
-  // TODO: handleKeyDown 함수 위치 조정 및 data 의존성 제거
-  // const handleKeyDown = (e: KeyboardEvent) => {
-  //   if (data) {
-  //     switch (e.key) {
-  //       case 'ArrowDown':
-  //         setKeywordIndex((prevState) => prevState + 1)
-  //         if (target.current?.childElementCount === keywordIndex + 1) setKeywordIndex(0)
-  //         break
-  //       case 'ArrowUp':
-  //         setKeywordIndex((prevState) => prevState - 1)
-  //         if (keywordIndex <= 0) {
-  //           // resultDataList([])
-  //           setKeywordIndex(-1)
-  //         }
-  //         break
-  //       case 'Escape':
-  //         setKeywordIndex(-1)
-  //         // resultDataList([])
-  //         break
-  //     }
-  //   }
-  // }
+  const handleKeyPress = (e: { key: string }) => {
+    if (keyword !== '') {
+      switch (e.key) {
+        case 'ArrowDown':
+          if (keywordIndex > count - 2) {
+            setKeywordIndex(0)
+            break
+          }
 
-  // memo: 강의 코드리뷰에서 나왔던 스타일로 리팩토링 했습니다.
-  // TODO: 스타일 작업 필요
+          setKeywordIndex((prevState) => prevState + 1)
+          break
 
-  // memo: 아래 코드가 data의 status를 변경시킵니다.
-  // useEffect(() => {
-  //   dispatch(setSearchWord({ keyword: target?.children[keywordIndex]?.innerText } as ISearchState))
-  // }, [dispatch, keywordIndex, target?.children])
+        case 'ArrowUp':
+          if (keywordIndex <= 0) {
+            setKeywordIndex(count - 1)
+            break
+          }
+
+          setKeywordIndex((prevState) => prevState - 1)
+          break
+
+        case 'Escape':
+          setKeywordIndex(-1)
+          break
+      }
+    }
+  }
 
   return (
     <>
@@ -53,8 +55,8 @@ const SearchPage = () => {
           <br />
           온라인으로 참여하기
         </h1>
-        <SearchBar />
-        <KeywordRecommends />
+        <SearchBar onKeyPress={handleKeyPress} />
+        <KeywordRecommends keywordIndex={keywordIndex} />
         <div className={styles.backgroundBottom}>
           <div className={styles.notification}>
             <p className={styles.notificationTxt}>새로운 임상시험이 등록되면 문자로 알려드려요</p>

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -3,10 +3,12 @@ import { RootState } from '../../types/search.d'
 
 export interface ISearchState {
   keyword: string | undefined
+  recommendsCount: number
 }
 
 const initialState: ISearchState = {
   keyword: '',
+  recommendsCount: 0,
 }
 
 // slice 안에 들어갈 내용들은 매우 심플하고 직관적이다.
@@ -17,12 +19,16 @@ export const searchSlice = createSlice({
   reducers: {
     setSearchWord(state, action: PayloadAction<ISearchState>) {
       // 업데이트 되는 State 를 return 해준다.
-      return { keyword: action.payload.keyword }
+      return { ...state, keyword: action.payload.keyword }
+    },
+    setRecommendsCount(state, action: PayloadAction<ISearchState>) {
+      return { ...state, recommendsCount: action.payload.recommendsCount }
     },
   },
 })
 
 export const searchWord = (state: RootState) => state.searchSlice.keyword
+export const recommendsCount = (state: RootState) => state.searchSlice.recommendsCount
 
 // 액션과 리듀서를 export 해준다. 이건 그냥 따라하면 된다.
-export const { setSearchWord } = searchSlice.actions
+export const { setSearchWord, setRecommendsCount } = searchSlice.actions

--- a/src/store/slices/searchSlice.ts
+++ b/src/store/slices/searchSlice.ts
@@ -2,12 +2,10 @@ import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 import { RootState } from '../../types/search.d'
 
 export interface ISearchState {
-  isOpen: boolean
   keyword: string | undefined
 }
 
 const initialState: ISearchState = {
-  isOpen: false,
   keyword: '',
 }
 
@@ -19,17 +17,12 @@ export const searchSlice = createSlice({
   reducers: {
     setSearchWord(state, action: PayloadAction<ISearchState>) {
       // 업데이트 되는 State 를 return 해준다.
-      return { isOpen: state.isOpen, keyword: action.payload.keyword }
-    },
-    setSearchToggle(state, action: PayloadAction<ISearchState>) {
-      // 업데이트 되는 State 를 return 해준다.
-      return { isOpen: action.payload.isOpen, keyword: state.keyword }
+      return { keyword: action.payload.keyword }
     },
   },
 })
 
 export const searchWord = (state: RootState) => state.searchSlice.keyword
-export const searchToggle = (state: RootState) => state.searchSlice.isOpen
 
 // 액션과 리듀서를 export 해준다. 이건 그냥 따라하면 된다.
-export const { setSearchWord, setSearchToggle } = searchSlice.actions
+export const { setSearchWord } = searchSlice.actions


### PR DESCRIPTION
## 내용

- `store`에서 `isOpen`, `setSearchToggle`을 제거했습니다.
- `handleKeyDown`을 다시 선언하고 동작하도록 만들었습니다.
  - 실제 동작 양상을 고려하여 `handleKeyPress`로 명명하였습니다.
  - 추가적으로 인덱스가 추천 검색어 리스트 밖으로 벗어나지 못하도록 했습니다.
    - 이 과정에서 추천 검색어의 개수를 가져올 수밖에 없어 부득이하게 중앙 저장소에 추천 검색어의 개수를 저장하도록 했습니다.

## 할 일

- `handleKeyPress`의 동작 양상이 바뀌어야 할 거 같습니다. 그리고 이 과정에서 선택이 필요할 거 같습니다.
  - 보통 키 이벤트로 자동 완성 검색어를 선택하면 인풋 값이 해당 값으로 업데이트 되는데 우리 상황은 그런 식으로 업데이트 하면 추천 검색어 리스트가 전부 변경됩니다. 이를 방지하려면 전역 `keyword`와 로컬 `inputValue`를 구분해야 할 것으로 보입니다. 