### PR TITLE
Hotfix/key handler

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@testing-library/user-event": "^13.2.1",
         "axios": "^0.27.2",
         "classnames": "^2.3.1",
+        "html-react-parser": "^1.4.12",
         "lodash.escaperegexp": "^4.1.2",
         "react": "^18.1.0",
         "react-dom": "^18.1.0",
@@ -8540,6 +8541,44 @@
         "safe-buffer": "~5.1.0"
       }
     },
+    "node_modules/html-dom-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.2.0.tgz",
+      "integrity": "sha512-2HIpFMvvffsXHFUFjso0M9LqM+1Lm22BF+Df2ba+7QHJXjk63pWChEnI6YG27eaWqUdfnh5/Vy+OXrNTtepRsg==",
+      "dependencies": {
+        "domhandler": "4.3.1",
+        "htmlparser2": "7.2.0"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/entities": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+      "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q==",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/html-dom-parser/node_modules/htmlparser2": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+      "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+      "funding": [
+        "https://github.com/fb55/htmlparser2?sponsor=1",
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fb55"
+        }
+      ],
+      "dependencies": {
+        "domelementtype": "^2.0.1",
+        "domhandler": "^4.2.2",
+        "domutils": "^2.8.0",
+        "entities": "^3.0.1"
+      }
+    },
     "node_modules/html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -8579,6 +8618,20 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/html-react-parser": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.12.tgz",
+      "integrity": "sha512-nqYQzr4uXh67G9ejAG7djupTHmQvSTgjY83zbXLRfKHJ0F06751jXx6WKSFARDdXxCngo2/7H4Rwtfeowql4gQ==",
+      "dependencies": {
+        "domhandler": "4.3.1",
+        "html-dom-parser": "1.2.0",
+        "react-property": "2.0.0",
+        "style-to-js": "1.1.0"
+      },
+      "peerDependencies": {
+        "react": "0.14 || 15 || 16 || 17 || 18"
       }
     },
     "node_modules/html-tags": {
@@ -8875,6 +8928,11 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "node_modules/internal-slot": {
       "version": "1.0.3",
@@ -14249,6 +14307,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "node_modules/react-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
+      "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
     "node_modules/react-query": {
       "version": "3.39.0",
       "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.0.tgz",
@@ -15804,6 +15867,22 @@
       "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
       "dev": true
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.0.tgz",
+      "integrity": "sha512-1OqefPDxGrlMwcbfpsTVRyzwdhr4W0uxYQzeA2F1CBc8WG04udg2+ybRnvh3XYL4TdHQrCahLtax2jc8xaE6rA==",
+      "dependencies": {
+        "style-to-object": "0.3.0"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+      "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+      "dependencies": {
+        "inline-style-parser": "0.1.1"
+      }
     },
     "node_modules/stylehacks": {
       "version": "5.1.0",
@@ -23796,6 +23875,33 @@
         }
       }
     },
+    "html-dom-parser": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/html-dom-parser/-/html-dom-parser-1.2.0.tgz",
+      "integrity": "sha512-2HIpFMvvffsXHFUFjso0M9LqM+1Lm22BF+Df2ba+7QHJXjk63pWChEnI6YG27eaWqUdfnh5/Vy+OXrNTtepRsg==",
+      "requires": {
+        "domhandler": "4.3.1",
+        "htmlparser2": "7.2.0"
+      },
+      "dependencies": {
+        "entities": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-3.0.1.tgz",
+          "integrity": "sha512-WiyBqoomrwMdFG1e0kqvASYfnlb0lp8M5o5Fw2OFq1hNZxxcNk8Ik0Xm7LxzBhuidnZB/UtBqVCgUz3kBOP51Q=="
+        },
+        "htmlparser2": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-7.2.0.tgz",
+          "integrity": "sha512-H7MImA4MS6cw7nbyURtLPO1Tms7C5H602LRETv95z1MxO/7CP7rDVROehUYeYBUYEON94NXXDEPmZuq+hX4sog==",
+          "requires": {
+            "domelementtype": "^2.0.1",
+            "domhandler": "^4.2.2",
+            "domutils": "^2.8.0",
+            "entities": "^3.0.1"
+          }
+        }
+      }
+    },
     "html-encoding-sniffer": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-2.0.1.tgz",
@@ -23826,6 +23932,17 @@
         "param-case": "^3.0.4",
         "relateurl": "^0.2.7",
         "terser": "^5.10.0"
+      }
+    },
+    "html-react-parser": {
+      "version": "1.4.12",
+      "resolved": "https://registry.npmjs.org/html-react-parser/-/html-react-parser-1.4.12.tgz",
+      "integrity": "sha512-nqYQzr4uXh67G9ejAG7djupTHmQvSTgjY83zbXLRfKHJ0F06751jXx6WKSFARDdXxCngo2/7H4Rwtfeowql4gQ==",
+      "requires": {
+        "domhandler": "4.3.1",
+        "html-dom-parser": "1.2.0",
+        "react-property": "2.0.0",
+        "style-to-js": "1.1.0"
       }
     },
     "html-tags": {
@@ -24027,6 +24144,11 @@
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
       "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew=="
+    },
+    "inline-style-parser": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.1.1.tgz",
+      "integrity": "sha512-7NXolsK4CAS5+xvdj5OMMbI962hU/wvwoxk+LWR9Ek9bVtyuuYScDN6eS0rUm6TxApFpw7CX1o4uJzcd4AyD3Q=="
     },
     "internal-slot": {
       "version": "1.0.3",
@@ -27772,6 +27894,11 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
     },
+    "react-property": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/react-property/-/react-property-2.0.0.tgz",
+      "integrity": "sha512-kzmNjIgU32mO4mmH5+iUyrqlpFQhF8K2k7eZ4fdLSOPFrD1XgEuSBv9LDEgxRXTMBqMd8ppT0x6TIzqE5pdGdw=="
+    },
     "react-query": {
       "version": "3.39.0",
       "resolved": "https://registry.npmjs.org/react-query/-/react-query-3.39.0.tgz",
@@ -28922,6 +29049,22 @@
       "resolved": "https://registry.npmjs.org/style-search/-/style-search-0.1.0.tgz",
       "integrity": "sha1-eVjHk+R+MuB9K1yv5cC/jhLneQI=",
       "dev": true
+    },
+    "style-to-js": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.0.tgz",
+      "integrity": "sha512-1OqefPDxGrlMwcbfpsTVRyzwdhr4W0uxYQzeA2F1CBc8WG04udg2+ybRnvh3XYL4TdHQrCahLtax2jc8xaE6rA==",
+      "requires": {
+        "style-to-object": "0.3.0"
+      }
+    },
+    "style-to-object": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-0.3.0.tgz",
+      "integrity": "sha512-CzFnRRXhzWIdItT3OmF8SQfWyahHhjq3HwcMNCNLn+N7klOOqPjMeG/4JSu77D7ypZdGvSzvkrbyeTMizz2VrA==",
+      "requires": {
+        "inline-style-parser": "0.1.1"
+      }
     },
     "stylehacks": {
       "version": "5.1.0",

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "@testing-library/user-event": "^13.2.1",
     "axios": "^0.27.2",
     "classnames": "^2.3.1",
+    "html-react-parser": "^1.4.12",
     "lodash.escaperegexp": "^4.1.2",
     "react": "^18.1.0",
     "react-dom": "^18.1.0",

--- a/src/components/Footer/Footer.module.scss
+++ b/src/components/Footer/Footer.module.scss
@@ -1,4 +1,4 @@
-@import 'styles/constants/colors';
+@use 'styles/constants/colors';
 
 .footer {
   position: absolute;
@@ -6,5 +6,5 @@
   left: 0;
   width: 100%;
   height: 90px;
-  background: $FOOTER;
+  background: colors.$FOOTER;
 }

--- a/src/components/KeywordRecommendItem/KeywordRecommendItem.module.scss
+++ b/src/components/KeywordRecommendItem/KeywordRecommendItem.module.scss
@@ -1,4 +1,4 @@
-@import 'styles/constants/colors';
+@use 'styles/constants/colors';
 
 .listKeyword {
   display: flex;
@@ -9,7 +9,7 @@
 }
 
 .focusKeyword {
-  background: $BACKGROUND;
+  background: colors.$BACKGROUND;
 }
 
 .keywordBtn {

--- a/src/components/KeywordRecommendItem/index.tsx
+++ b/src/components/KeywordRecommendItem/index.tsx
@@ -1,6 +1,7 @@
 import { useDispatch } from 'react-redux'
 import { useNavigate } from 'react-router-dom'
 import cx from 'classnames'
+import parse from 'html-react-parser'
 
 import { MagnifyingGlassIcon } from 'assets/svgs'
 
@@ -54,11 +55,9 @@ const KeywordRecommendItem = ({ keyword, keywordItem, isFocused }: SearchKeyword
         <div className={styles.icon}>
           <MagnifyingGlassIcon className={styles.icon} />
         </div>
-        <div
-          className={styles.keywordName}
-          aria-label={keywordItem.sickNm}
-          dangerouslySetInnerHTML={{ __html: markedKeywordHtml }}
-        />
+        <div className={styles.keywordName} aria-label={keywordItem.sickNm}>
+          {parse(markedKeywordHtml)}
+        </div>
       </button>
     </li>
   )

--- a/src/components/KeywordRecommends/KeywordRecommends.module.scss
+++ b/src/components/KeywordRecommends/KeywordRecommends.module.scss
@@ -4,13 +4,16 @@
 .keywordListForm {
   position: relative;
   z-index: levels.$KEYWORDFORM;
+  display: none;
   width: 520px;
   min-width: 330px;
   margin-top: 6px;
   background: colors.$WHITE;
   border-radius: 20px;
 
+  // TODO: active 검사 시간 동안 요소가 보이는 문제
   &.active {
+    display: block;
     padding: 10px 20px;
   }
 

--- a/src/components/KeywordRecommends/KeywordRecommends.module.scss
+++ b/src/components/KeywordRecommends/KeywordRecommends.module.scss
@@ -1,6 +1,5 @@
 @use '/src/styles/constants/levels';
 @use '/src/styles/constants/colors';
-// TODO: import => use로 다 바꾸기
 
 .keywordListForm {
   position: relative;

--- a/src/components/KeywordRecommends/index.tsx
+++ b/src/components/KeywordRecommends/index.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from 'react'
+import { useEffect, useMemo } from 'react'
 import { useSelector, useDispatch } from 'react-redux'
 import { useQuery } from 'react-query'
 import cx from 'classnames'
@@ -24,13 +24,14 @@ const KeywordRecommends = ({ keywordIndex }: { keywordIndex: number }) => {
       retry: 1,
       staleTime: 60 * 60 * 1000,
       enabled: !!debouncedKeyword,
-      onSuccess: (res) => {
-        dispatch(setRecommendsCount({ recommendsCount: res.length } as ISearchState))
-      },
     }
   )
 
   const fuzzyData = applyFuzzyMatch(data || [], keyword)
+
+  useEffect(() => {
+    dispatch(setRecommendsCount({ recommendsCount: fuzzyData.length } as ISearchState))
+  }, [data, dispatch, fuzzyData])
 
   const Recommends = useMemo(() => {
     if (isLoading) {

--- a/src/components/KeywordRecommends/index.tsx
+++ b/src/components/KeywordRecommends/index.tsx
@@ -37,6 +37,7 @@ const KeywordRecommends = ({ keywordIndex }: { keywordIndex: number }) => {
     if (isLoading) {
       return <div className={styles.loading}>Loading...</div>
     }
+
     if (data && keyword && fuzzyData.length === 0) {
       return <div className={styles.nothing}>추천 검색어가 없습니다</div>
     }

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent } from 'react'
+import { ChangeEvent, FormEvent, SetStateAction, Dispatch } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 
@@ -8,7 +8,12 @@ import { MagnifyingGlassIcon } from 'assets/svgs'
 
 import styles from './SearchBar.module.scss'
 
-const SearchBar = ({ keywordIndex, setKeywordIndex }: any) => {
+interface ISearchBar {
+  keywordIndex: number
+  setKeywordIndex: Dispatch<SetStateAction<number>>
+}
+
+const SearchBar = ({ keywordIndex, setKeywordIndex }: ISearchBar) => {
   const dispatch = useDispatch()
   const navigate = useNavigate()
   const inputValue = useSelector(searchInput)

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -2,15 +2,62 @@ import { ChangeEvent, FormEvent } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { useDispatch, useSelector } from 'react-redux'
 
+import { searchWord, recommendsCount, setSearchWord, ISearchState } from 'store/slices/searchSlice'
+import { ISearchInputState, searchInput, setSearchInputValue } from 'store/slices/searchInputSlice'
 import { MagnifyingGlassIcon } from 'assets/svgs'
 
 import styles from './SearchBar.module.scss'
-import { ISearchInputState, searchInput, setSearchInputValue } from 'store/slices/searchInputSlice'
 
-const SearchBar = ({ onKeyUp }: { onKeyUp: React.KeyboardEventHandler<HTMLInputElement> }) => {
+const SearchBar = ({ keywordIndex, setKeywordIndex }: any) => {
   const dispatch = useDispatch()
   const navigate = useNavigate()
   const inputValue = useSelector(searchInput)
+  const keyword = useSelector(searchWord)
+  const count = useSelector(recommendsCount)
+
+  const handleKeyUp = (e: { key: string }) => {
+    if (e.key === 'Process') {
+      setKeywordIndex(-1)
+      dispatch(setSearchWord({ keyword: inputValue } as ISearchState))
+      dispatch(setSearchInputValue({ searchInputValue: inputValue } as ISearchInputState))
+      return
+    }
+
+    if (keyword === '') return
+
+    if (e.key === 'Backspace') {
+      setKeywordIndex(-1)
+      dispatch(setSearchWord({ keyword: inputValue } as ISearchState))
+      dispatch(setSearchInputValue({ searchInputValue: inputValue } as ISearchInputState))
+      return
+    }
+
+    if (e.key === 'ArrowDown') {
+      if (keywordIndex > count - 2) {
+        setKeywordIndex(0)
+        return
+      }
+
+      setKeywordIndex((prevState: number) => prevState + 1)
+      return
+    }
+
+    if (e.key === 'ArrowUp') {
+      if (keywordIndex <= 0) {
+        setKeywordIndex(count - 1)
+        return
+      }
+
+      setKeywordIndex((prevState: number) => prevState - 1)
+      return
+    }
+
+    if (e.key === 'Escape') {
+      setKeywordIndex(-1)
+      dispatch(setSearchWord({ keyword: '' } as ISearchState))
+      dispatch(setSearchInputValue({ searchInputValue: '' } as ISearchInputState))
+    }
+  }
 
   const handleKeywordSubmit = (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault()
@@ -28,7 +75,7 @@ const SearchBar = ({ onKeyUp }: { onKeyUp: React.KeyboardEventHandler<HTMLInputE
         <MagnifyingGlassIcon />
       </div>
       <input
-        onKeyUp={onKeyUp}
+        onKeyUp={handleKeyUp}
         className={styles.input}
         type='search'
         placeholder='질환명을 입력해주세요.'

--- a/src/components/SearchBar/index.tsx
+++ b/src/components/SearchBar/index.tsx
@@ -7,7 +7,7 @@ import { MagnifyingGlassIcon } from 'assets/svgs'
 import styles from './SearchBar.module.scss'
 import { ISearchInputState, searchInput, setSearchInputValue } from 'store/slices/searchInputSlice'
 
-const SearchBar = ({ onKeyPress }: { onKeyPress: React.KeyboardEventHandler<HTMLInputElement> }) => {
+const SearchBar = ({ onKeyUp }: { onKeyUp: React.KeyboardEventHandler<HTMLInputElement> }) => {
   const dispatch = useDispatch()
   const navigate = useNavigate()
   const inputValue = useSelector(searchInput)
@@ -28,7 +28,7 @@ const SearchBar = ({ onKeyPress }: { onKeyPress: React.KeyboardEventHandler<HTML
         <MagnifyingGlassIcon />
       </div>
       <input
-        onKeyUp={onKeyPress}
+        onKeyUp={onKeyUp}
         className={styles.input}
         type='search'
         placeholder='질환명을 입력해주세요.'

--- a/src/routes/SearchPage/SearchPage.module.scss
+++ b/src/routes/SearchPage/SearchPage.module.scss
@@ -1,5 +1,4 @@
-@import 'styles/base/fonts';
-@import 'styles/constants/colors';
+@use 'styles/constants/colors';
 
 .section {
   display: flex;
@@ -7,7 +6,7 @@
   align-items: center;
   width: 100%;
   height: 81.5%;
-  background: $BACKGROUND;
+  background: colors.$BACKGROUND;
 }
 
 .description {

--- a/src/routes/SearchPage/SearchPage.module.scss
+++ b/src/routes/SearchPage/SearchPage.module.scss
@@ -1,5 +1,9 @@
 @use 'styles/constants/colors';
 
+input::-webkit-search-cancel-button {
+  display: none;
+}
+
 .section {
   display: flex;
   flex-direction: column;

--- a/src/routes/SearchPage/index.tsx
+++ b/src/routes/SearchPage/index.tsx
@@ -7,7 +7,7 @@ import KeywordRecommends from 'components/KeywordRecommends'
 
 import styles from './SearchPage.module.scss'
 import Banner from 'components/Banner'
-import { searchInput } from 'store/slices/searchInputSlice'
+import { ISearchInputState, searchInput, setSearchInputValue } from 'store/slices/searchInputSlice'
 
 const SearchPage = () => {
   const dispatch = useDispatch()
@@ -16,37 +16,47 @@ const SearchPage = () => {
   const count = useSelector(recommendsCount)
   const [keywordIndex, setKeywordIndex] = useState(-1)
 
-  const handleKeyPress = (e: { key: string }) => {
+  const handleKeyUp = (e: { key: string }) => {
     if (e.key === 'Process') {
       setKeywordIndex(-1)
-    }
-    if (e.key !== 'ArrowDown' && e.key !== 'ArrowUp' && e.key !== 'Escape') {
       dispatch(setSearchWord({ keyword: inputValue } as ISearchState))
+      dispatch(setSearchInputValue({ searchInputValue: inputValue } as ISearchInputState))
+      return
     }
-    if (keyword !== '') {
-      switch (e.key) {
-        case 'ArrowDown':
-          if (keywordIndex > count - 2) {
-            setKeywordIndex(0)
-            break
-          }
 
-          setKeywordIndex((prevState) => prevState + 1)
-          break
+    if (keyword === '') return
 
-        case 'ArrowUp':
-          if (keywordIndex <= 0) {
-            setKeywordIndex(count - 1)
-            break
-          }
+    if (e.key === 'Backspace') {
+      setKeywordIndex(-1)
+      dispatch(setSearchWord({ keyword: inputValue } as ISearchState))
+      dispatch(setSearchInputValue({ searchInputValue: inputValue } as ISearchInputState))
+      return
+    }
 
-          setKeywordIndex((prevState) => prevState - 1)
-          break
-
-        case 'Escape':
-          setKeywordIndex(-1)
-          break
+    if (e.key === 'ArrowDown') {
+      if (keywordIndex > count - 2) {
+        setKeywordIndex(0)
+        return
       }
+
+      setKeywordIndex((prevState) => prevState + 1)
+      return
+    }
+
+    if (e.key === 'ArrowUp') {
+      if (keywordIndex <= 0) {
+        setKeywordIndex(count - 1)
+        return
+      }
+
+      setKeywordIndex((prevState) => prevState - 1)
+      return
+    }
+
+    if (e.key === 'Escape') {
+      setKeywordIndex(-1)
+      dispatch(setSearchWord({ keyword: '' } as ISearchState))
+      dispatch(setSearchInputValue({ searchInputValue: '' } as ISearchInputState))
     }
   }
 
@@ -57,7 +67,7 @@ const SearchPage = () => {
         <br />
         온라인으로 참여하기
       </h1>
-      <SearchBar onKeyPress={handleKeyPress} />
+      <SearchBar onKeyUp={handleKeyUp} />
       <KeywordRecommends keywordIndex={keywordIndex} />
       <Banner />
     </section>

--- a/src/routes/SearchPage/index.tsx
+++ b/src/routes/SearchPage/index.tsx
@@ -1,64 +1,13 @@
 import { useState } from 'react'
-import { useDispatch, useSelector } from 'react-redux'
 
-import { searchWord, recommendsCount, setSearchWord, ISearchState } from 'store/slices/searchSlice'
 import SearchBar from 'components/SearchBar'
 import KeywordRecommends from 'components/KeywordRecommends'
 
 import styles from './SearchPage.module.scss'
 import Banner from 'components/Banner'
-import { ISearchInputState, searchInput, setSearchInputValue } from 'store/slices/searchInputSlice'
 
 const SearchPage = () => {
-  const dispatch = useDispatch()
-  const inputValue = useSelector(searchInput)
-  const keyword = useSelector(searchWord)
-  const count = useSelector(recommendsCount)
   const [keywordIndex, setKeywordIndex] = useState(-1)
-
-  const handleKeyUp = (e: { key: string }) => {
-    if (e.key === 'Process') {
-      setKeywordIndex(-1)
-      dispatch(setSearchWord({ keyword: inputValue } as ISearchState))
-      dispatch(setSearchInputValue({ searchInputValue: inputValue } as ISearchInputState))
-      return
-    }
-
-    if (keyword === '') return
-
-    if (e.key === 'Backspace') {
-      setKeywordIndex(-1)
-      dispatch(setSearchWord({ keyword: inputValue } as ISearchState))
-      dispatch(setSearchInputValue({ searchInputValue: inputValue } as ISearchInputState))
-      return
-    }
-
-    if (e.key === 'ArrowDown') {
-      if (keywordIndex > count - 2) {
-        setKeywordIndex(0)
-        return
-      }
-
-      setKeywordIndex((prevState) => prevState + 1)
-      return
-    }
-
-    if (e.key === 'ArrowUp') {
-      if (keywordIndex <= 0) {
-        setKeywordIndex(count - 1)
-        return
-      }
-
-      setKeywordIndex((prevState) => prevState - 1)
-      return
-    }
-
-    if (e.key === 'Escape') {
-      setKeywordIndex(-1)
-      dispatch(setSearchWord({ keyword: '' } as ISearchState))
-      dispatch(setSearchInputValue({ searchInputValue: '' } as ISearchInputState))
-    }
-  }
 
   return (
     <section className={styles.section}>
@@ -67,7 +16,7 @@ const SearchPage = () => {
         <br />
         온라인으로 참여하기
       </h1>
-      <SearchBar onKeyUp={handleKeyUp} />
+      <SearchBar keywordIndex={keywordIndex} setKeywordIndex={setKeywordIndex} />
       <KeywordRecommends keywordIndex={keywordIndex} />
       <Banner />
     </section>

--- a/src/routes/SearchPage/index.tsx
+++ b/src/routes/SearchPage/index.tsx
@@ -1,5 +1,8 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
+import { useDispatch } from 'react-redux'
 
+import { setSearchWord, ISearchState } from 'store/slices/searchSlice'
+import { ISearchInputState, setSearchInputValue } from 'store/slices/searchInputSlice'
 import SearchBar from 'components/SearchBar'
 import KeywordRecommends from 'components/KeywordRecommends'
 
@@ -7,7 +10,13 @@ import styles from './SearchPage.module.scss'
 import Banner from 'components/Banner'
 
 const SearchPage = () => {
+  const dispatch = useDispatch()
   const [keywordIndex, setKeywordIndex] = useState(-1)
+
+  useEffect(() => {
+    dispatch(setSearchInputValue({ searchInputValue: '' } as ISearchInputState))
+    dispatch(setSearchWord({ keyword: '' } as ISearchState))
+  }, [dispatch])
 
   return (
     <section className={styles.section}>

--- a/src/services/search.ts
+++ b/src/services/search.ts
@@ -6,13 +6,14 @@ interface DiseaseListResponse {
   item: IDisease[]
 }
 
-let count = 0
+let apiCallCount = 0
 
 export const getDiseaseData = async (keyword: string) => {
   if (keyword === '') return []
 
-  count += 1
-  console.log('count:', count)
+  apiCallCount += 1
+  // eslint-disable-next-line no-console
+  console.log('API 호출 횟수:', apiCallCount)
 
   const {
     data: { item },

--- a/src/utils/fuzzySearch.ts
+++ b/src/utils/fuzzySearch.ts
@@ -81,10 +81,9 @@ export function applyFuzzyMatch(data: IDisease[], keyword: string) {
 
       return { ...row, longestDistance }
     })
-
-  fuzzyData.sort((a, b) => {
-    return a.longestDistance - b.longestDistance
-  })
+    .sort((a, b) => {
+      return a.longestDistance - b.longestDistance
+    })
 
   return fuzzyData.slice(0, 7)
 }


### PR DESCRIPTION
- `dangerouslySetInnerHTML`을 `html-react-parser`을 이용해서 안전하게 동작하도록 했습니다.

- input의 기본 취소 버튼을 지웠습니다.
- 페이지 마운트시 input에 있는 값을 초기화합니다.
- 키 이벤트 핸들러가 정상적으로 동작하도록 했습니다.
  - 관련 이슈: 이전 PR에서 api 호출시 추천 검색어 목록을 최대 7개 가져오던 것에서 전체를 가져오는 것으로 변경되면서 생긴 문제가 있었습니다.
 - 키 이벤트 핸들러를 `SearchBar`로 옮겼습니다.